### PR TITLE
added missing assert package to package.json, fixed timezone issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "personnummer.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -297,6 +297,12 @@
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@types/assert": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.2.tgz",
+      "integrity": "sha512-DLsoZH9z5DLDi6qMbXKqeqlQLK1h3rfR9dK+KX8UJSGHJylvIZPOCQEKr/d/FClPoZE/eHOa3+e270eUJCUTog==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "@types/mocha": "^7.0.2",
         "@typescript-eslint/eslint-plugin": "^2.29.0",
         "@typescript-eslint/parser": "^2.29.0",
+        "@types/assert": "^1.5.2",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-node": "^11.1.0",

--- a/src/personalNumber/parse.ts
+++ b/src/personalNumber/parse.ts
@@ -91,7 +91,7 @@ function parse(input: string | number, options: PersonalNumberOptions): Personal
 
     // normalises the personal number to the format year|month|day|serial|gender|checksum
     // e.g. 970214-5641 will become 199702145641
-    const normalised = "" + date.getFullYear() + monthNum + dayNum + serialNum + genderNum + checkNum;
+    const normalised = "" + date.getUTCFullYear() + monthNum + dayNum + serialNum + genderNum + checkNum;
 
     // parses the gender according the personal number definition, if the second last number is even it is a female, otherwise a male
     let gender: GenderType = "MALE";

--- a/src/personalNumber/parseDate.ts
+++ b/src/personalNumber/parseDate.ts
@@ -27,7 +27,7 @@ function parseDate(year: number, month: number, date: number, sep: string, centu
     const validDate = new Date(Date.UTC(currentCentury + year, month, date));
 
     // checks if it is the same date as the input date
-    if (parseInt(validDate.getFullYear().toString().slice(2, 4)) === year && validDate.getMonth() === month && validDate.getDate() === date) {
+    if (parseInt(validDate.getUTCFullYear().toString().slice(2, 4)) === year && validDate.getUTCMonth() === month && validDate.getUTCDate() === date) {
         return { valid: true, date: validDate };
     }
 

--- a/test/personnummer-js.test.ts
+++ b/test/personnummer-js.test.ts
@@ -32,6 +32,8 @@ describe("#normalisePN()", function () {
         assert.strictEqual(normalisePN("9303114202"),"199303114202");
         assert.strictEqual(normalisePN("19181129+3057"),"191811293057");
         assert.strictEqual(normalisePN("0001018126"), "200001018126");
+        assert.strictEqual(normalisePN("000101-8126"), "200001018126");
+        assert.strictEqual(normalisePN("000101+8126"), "190001018126");
         assert.strictEqual(normalisePN("071029-0024"),"200710290024");
         assert.strictEqual(normalisePN("030405-9231"),"200304059231");
     });

--- a/test/personnummer-js.test.ts
+++ b/test/personnummer-js.test.ts
@@ -9,122 +9,123 @@ import { parse as parsePN, validate as validatePN, normalise as normalisePN, par
 
 describe("#luhnAlgorithm()", function () {
     it("should return correct: luhn number", function () {
-        assert.strictEqual(6, luhnAlgorithm(811218987));
-        assert.strictEqual(6, luhnAlgorithm("000101812"));
-        assert.strictEqual(0, luhnAlgorithm(870723534));
-        assert.strictEqual(2, luhnAlgorithm("930311420"));
+        assert.strictEqual(luhnAlgorithm(811218987), 6);
+        assert.strictEqual(luhnAlgorithm("000101812"), 6);
+        assert.strictEqual(luhnAlgorithm(870723534), 0);
+        assert.strictEqual(luhnAlgorithm("930311420"), 2);
     });
 });
 
 describe("#parseDate()", function () {
     it("should return correct: luhn number", function () {
-        assert.strictEqual(6, luhnAlgorithm(811218987));
-        assert.strictEqual(6, luhnAlgorithm("000101812"));
-        assert.strictEqual(0, luhnAlgorithm(870723534));
-        assert.strictEqual(2, luhnAlgorithm("930311420"));
+        assert.strictEqual(luhnAlgorithm(811218987), 6);
+        assert.strictEqual(luhnAlgorithm("000101812"), 6);
+        assert.strictEqual(luhnAlgorithm(870723534), 0);
+        assert.strictEqual(luhnAlgorithm("930311420"), 2);
     });
 });
 
 describe("#normalisePN()", function () {
     it("should return correct: normalised personal number", function () {
-        assert.strictEqual("194501038220", normalisePN("450103-8220"));
-        assert.strictEqual("198707235340", normalisePN(8707235340));
-        assert.strictEqual("199303114202", normalisePN("9303114202"));
-        assert.strictEqual("191811293057", normalisePN("19181129+3057"));
-        assert.strictEqual("200001018126", normalisePN("0001018126"));
-        assert.strictEqual("200710290024", normalisePN("071029-0024"));
-        assert.strictEqual("200304059231", normalisePN("030405-9231"));
+        assert.strictEqual(normalisePN("450103-8220"), "194501038220");
+        assert.strictEqual(normalisePN(8707235340), "198707235340");
+        assert.strictEqual(normalisePN("9303114202"),"199303114202");
+        assert.strictEqual(normalisePN("19181129+3057"),"191811293057");
+        assert.strictEqual(normalisePN("0001018126"), "200001018126");
+        assert.strictEqual(normalisePN("071029-0024"),"200710290024");
+        assert.strictEqual(normalisePN("030405-9231"),"200304059231");
     });
 });
 
 describe("#validatePN()", function () {
     it("should validate: correct personnummer", function () {
-        assert.strictEqual(true, validatePN("450103-8220"));
-        assert.strictEqual(true, validatePN("870613-5657"));
-        assert.strictEqual(true, validatePN(9307174459));
-        assert.strictEqual(true, validatePN("0010237808"));
-        assert.strictEqual(true, validatePN("0512240169"));
-        assert.strictEqual(true, validatePN("150314+5425"));
-        assert.strictEqual(true, validatePN("0512240169"));
-        assert.strictEqual(true, validatePN("19181129+3057"));
+        assert.strictEqual(validatePN("450103-8220"), true);
+        assert.strictEqual(validatePN("870613-5657"), true);
+        assert.strictEqual(validatePN(9307174459), true);
+        assert.strictEqual(validatePN("0010237808"), true);
+        assert.strictEqual(validatePN("0512240169"), true);
+        assert.strictEqual(validatePN("150314+5425"), true);
+        assert.strictEqual(validatePN("0512240169"), true);
+        assert.strictEqual(validatePN("19181129+3057"), true);
     });
 
+
     it("should not validate: incorrect personnummer dates", function () {
-        assert.strictEqual(false, validatePN("999999-5476"));
-        assert.strictEqual(false, validatePN("191313-8473"));
-        assert.strictEqual(false, validatePN(1006334351));
-        assert.strictEqual(false, validatePN("0014234561"));
+        assert.strictEqual(validatePN("999999-5476"), false);
+        assert.strictEqual(validatePN("191313-8473"), false);
+        assert.strictEqual(validatePN(1006334351), false);
+        assert.strictEqual(validatePN("0014234561"), false);
     });
 
     it("should not validate: incorrect personnummer format or incorrect type", function () {
-        assert.strictEqual(false, validatePN(undefined as any));
-        assert.strictEqual(false, validatePN(null as any));
-        assert.strictEqual(false, validatePN([] as any));
-        assert.strictEqual(false, validatePN({} as any));
-        assert.strictEqual(false, validatePN(false as any));
-        assert.strictEqual(false, validatePN(true as any));
-        assert.strictEqual(false, validatePN(123));
-        assert.strictEqual(false, validatePN("123"));
-        assert.strictEqual(false, validatePN("123-123"));
-        assert.strictEqual(false, validatePN("123_123"));
-        assert.strictEqual(false, validatePN("123?123"));
-        assert.strictEqual(false, validatePN("string"));
-        assert.strictEqual(false, validatePN("123-abc"));
-        assert.strictEqual(false, validatePN("670427-554"));
-        assert.strictEqual(false, validatePN("040229-074"));
+        assert.strictEqual(validatePN(undefined as any), false);
+        assert.strictEqual(validatePN(null as any), false);
+        assert.strictEqual(validatePN([] as any), false);
+        assert.strictEqual(validatePN({} as any), false);
+        assert.strictEqual(validatePN(false as any), false);
+        assert.strictEqual(validatePN(true as any), false);
+        assert.strictEqual(validatePN(123), false);
+        assert.strictEqual(validatePN("123"), false);
+        assert.strictEqual(validatePN("123-123"), false);
+        assert.strictEqual(validatePN("123_123"), false);
+        assert.strictEqual(validatePN("123?123"), false);
+        assert.strictEqual(validatePN("string"), false);
+        assert.strictEqual(validatePN("123-abc"), false);
+        assert.strictEqual(validatePN("670427-554"), false);
+        assert.strictEqual(validatePN("040229-074"), false);
     });
 
     it("should not validate: incorrect personnummer checksum", function () {
-        assert.strictEqual(false, validatePN("320323-9325"));
-        assert.strictEqual(false, validatePN("870514-3202"));
-        assert.strictEqual(false, validatePN(1806282244));
-        assert.strictEqual(false, validatePN("471224-0907"));
+        assert.strictEqual(validatePN("320323-9325"),false);
+        assert.strictEqual(validatePN("870514-3202"),false);
+        assert.strictEqual(validatePN(1806282244), false);
+        assert.strictEqual(validatePN("471224-0907"), false);
     });
 
     it("should validate: co-ordination numbers", function () {
-        assert.strictEqual(true, validatePN("0411643844"));
-        assert.strictEqual(true, validatePN(1103784755));
-        assert.strictEqual(true, validatePN("0311803860"));
-        assert.strictEqual(true, validatePN("430688-0362"));
+        assert.strictEqual(validatePN("0411643844"), true);
+        assert.strictEqual(validatePN(1103784755), true);
+        assert.strictEqual(validatePN("0311803860"), true);
+        assert.strictEqual(validatePN("430688-0362"), true);
     });
 
     it("should not validate: incorrect co-ordination numbers", function () {
-        assert.strictEqual(false, validatePN("370567-4738"));
-        assert.strictEqual(false, validatePN("871161-2345"));
-        assert.strictEqual(false, validatePN(121272846));
-        assert.strictEqual(false, validatePN("080690-4857"));
+        assert.strictEqual(validatePN("370567-4738"), false);
+        assert.strictEqual(validatePN("871161-2345"), false);
+        assert.strictEqual(validatePN(121272846), false);
+        assert.strictEqual(validatePN("080690-4857"), false);
     });
 
     it("should validate: correct leapyear", function () {
-        assert.strictEqual(true, validatePN("20000229-6127"));
-        assert.strictEqual(true, validatePN(9602296973));
-        assert.strictEqual(true, validatePN(9202294402));
-        assert.strictEqual(true, validatePN("960229-6973"));
+        assert.strictEqual(validatePN("20000229-6127"), true);
+        assert.strictEqual(validatePN(9602296973), true);
+        assert.strictEqual(validatePN(9202294402), true);
+        assert.strictEqual(validatePN("960229-6973"), true);
     });
 
     it("should not validate: incorrect leapyear", function () {
-        assert.strictEqual(false, validatePN("20010229-2391"));
-        assert.strictEqual(false, validatePN(9802293231));
-        assert.strictEqual(false, validatePN(200002293243));
-        assert.strictEqual(false, validatePN("960229-4534"));
+        assert.strictEqual(validatePN("20010229-2391"), false);
+        assert.strictEqual(validatePN(9802293231), false);
+        assert.strictEqual(validatePN(200002293243), false);
+        assert.strictEqual(validatePN("960229-4534"), false);
     });
 });
 
 describe("#validateCIN()", function () {
     it("should validate correct: corporate identity number", function () {
-        assert.strictEqual(true, validateCIN("502068-4865"));
-        assert.strictEqual(true, validateCIN("556754-8283"));
-        assert.strictEqual(true, validateCIN("802521-6220"));
-        assert.strictEqual(true, validateCIN("802467-7182"));
+        assert.strictEqual(validateCIN("502068-4865"), true);
+        assert.strictEqual(validateCIN("556754-8283"), true);
+        assert.strictEqual(validateCIN("802521-6220"), true);
+        assert.strictEqual(validateCIN("802467-7182"), true);
     });
 });
 
 describe("#normaliseCIN()", function () {
     it("should normalise correct: corporate identity number", function () {
-        assert.strictEqual("165020684865", normaliseCIN("502068-4865"));
-        assert.strictEqual("165567548283", normaliseCIN("5567548283"));
-        assert.strictEqual("168025216220", normaliseCIN("16802521-6220"));
-        assert.strictEqual("168024677182", normaliseCIN("168024677182"));
-        assert.strictEqual("198706135657", normaliseCIN("870613-5657"));
+        assert.strictEqual(normaliseCIN("502068-4865"),"165020684865");
+        assert.strictEqual(normaliseCIN("5567548283"), "165567548283");
+        assert.strictEqual(normaliseCIN("16802521-6220"),"168025216220");
+        assert.strictEqual(normaliseCIN("168024677182"), "168024677182");
+        assert.strictEqual(normaliseCIN("870613-5657"), "198706135657");
     });
 });


### PR DESCRIPTION
Things fixed in this PR

- Added missing assert package.
- Fixed tests to reflect the API.
- Fixed conversion and validation for different timezones as switching timezone would make the tests fail.
- Add test case

Switching to another timezone would make a valid personnummer fail.

Had a problem with ts compilation, the code in the test file was unreachable. Did some investigation and fixed the issue by switching the place of the parameters to reflect assert.strictEqual(actual, expected)  
[strictEqual node doc](https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message)